### PR TITLE
Add "number" as a valid textInput type to allow advanced functionality

### DIFF
--- a/src/widgets/form/TextInput.js
+++ b/src/widgets/form/TextInput.js
@@ -47,7 +47,8 @@ troop.postpone(candystore, 'TextInput', function (ns, className, /**jQuery*/$) {
                 email   : 'email',
                 search  : 'search',
                 tel     : 'tel',
-                url     : 'url'
+                url     : 'url',
+		number  : 'number'
             }
         })
         .addPrivateMethods(/** @lends candystore.TextInput# */{


### PR DESCRIPTION
Hi Dan,

I believe that number should be considered a valid textInput. Without this fix the floating field magic fails.