### PR TITLE
fixes Popup to compare UI events during the UI event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name"           : "candystore",
-    "version"        : "0.7.3",
+    "version"        : "0.7.4",
     "description"    : "Common widgets",
     "keywords"       : [
         "widgets",

--- a/src/behaviors/Popup.js
+++ b/src/behaviors/Popup.js
@@ -187,7 +187,7 @@ troop.postpone(candystore, 'Popup', function (ns, className, /**jQuery*/$) {
              * @returns {candystore.Popup}
              */
             closePopup: function () {
-                if (this.isOpen && this.openUiEvent !== this._getLastUiEvent()) {
+                if (this.isOpen) {
                     // must set flag before triggering event
                     // otherwise event handlers would see mixed state
                     // (event says it's closed, but widget state says it's open)
@@ -238,7 +238,9 @@ troop.postpone(candystore, 'Popup', function (ns, className, /**jQuery*/$) {
              */
             onOutsideClick: function (event) {
                 var link = evan.pushOriginalEvent(event);
-                this.closePopup();
+                if (this.openUiEvent !== this._getLastUiEvent()) {
+                    this.closePopup();
+                }
                 link.unLink();
             },
 


### PR DESCRIPTION
Previously overrides to closePopup which introduced a delay would
allow further UI events to fire and the wrong event would be
compared with the event which triggered the popup to open.