### PR TITLE
Fix Uncaught TypeError on reload page while holding a key down

### DIFF
--- a/src/widgets/utils/HotKeyWatcher.js
+++ b/src/widgets/utils/HotKeyWatcher.js
@@ -33,13 +33,15 @@ troop.postpone(candystore, 'HotKeyWatcher', function () {
 
                 var link = evan.pushOriginalEvent(event);
 
-                rootWidget
-                    .spawnEvent(this.EVENT_HOT_KEY_DOWN)
-                    .setPayloadItems({
-                        charCode    : event.which,
-                        originWidget: originWidget
-                    })
-                    .broadcastSync();
+                if (rootWidget) {
+                    rootWidget
+                        .spawnEvent(this.EVENT_HOT_KEY_DOWN)
+                        .setPayloadItems({
+                            charCode    : event.which,
+                            originWidget: originWidget
+                        })
+                        .broadcastSync();
+                }
 
                 link.unLink();
             }


### PR DESCRIPTION
To replicate.

Reload page, and hold any key down while page is loading.

```
Uncaught TypeError: Cannot read property 'spawnEvent' of undefined
candystore.HotKeyWatcher.self.addConstants.addMethods.onKeyDown @ candystore.js:2279
(anonymous function) @ candystore.js:2296
jQuery.event.dispatch @ jquery.js:4430
jQuery.event.add.elemData.handle @ jquery.js:
```
